### PR TITLE
fix failing code sample on README

### DIFF
--- a/chargebee-js-react/README.md
+++ b/chargebee-js-react/README.md
@@ -26,7 +26,7 @@ In your `index.html`:
         <script src="https://js.chargebee.com/v2/chargebee.js"></script>
         <script>
             Chargebee.init({
-                site: 'your-site'
+                site: 'your-site',
                 publishableKey: 'your-publishable-key'
             })
         </script>


### PR DESCRIPTION
I copied from the readme and pasted into my code and it failed because of the missing comma. This could save other users (especially newbies) from the hassle of trying to figure out why it fails