### PR TITLE
Support Angular >= 18

### DIFF
--- a/chargebee-js-angular/projects/chargebee-js-angular-wrapper/package.json
+++ b/chargebee-js-angular/projects/chargebee-js-angular-wrapper/package.json
@@ -25,7 +25,7 @@
     "chargebee.js angular"
   ],
   "peerDependencies": {
-    "@angular/common": "^18.2.13",
-    "@angular/core": "^18.2.13"
+    "@angular/common": ">=18.2.13",
+    "@angular/core": ">=18.2.13"
   }
 }


### PR DESCRIPTION
- Fixes #171 

In general, Angular is really backwards compatible. Imo it's better to risk the rare chance of breakage down the line than to have it break with every single Angular update.